### PR TITLE
minor change to give user option of not displaying the PC plot 

### DIFF
--- a/R/CIDR.R
+++ b/R/CIDR.R
@@ -327,6 +327,7 @@ setGeneric("scPCA", function(object) {
 #' @name scPCA
 #'
 #' @param object an scData class object.
+#' @param pcplot if TRUE, a plot of the PC variance explained is shown
 #'
 #' @export
 #'
@@ -338,7 +339,7 @@ setGeneric("scPCA", function(object) {
 #'
 #' @examples
 #' example(cidr)
-setMethod("scPCA", "scData", function(object){
+setMethod("scPCA", "scData", function(object,pcplot=TRUE){
     y <- cidrPcoa(object@dissim)
     variation <- y$values
     ## store all eigenvalues - neg, 0, & pos
@@ -349,7 +350,7 @@ setMethod("scPCA", "scData", function(object){
     variation <- variation/sum(variation)
     object@variation <- variation
 
-    plot(object@variation, xlab="PC", ylab="Proportion", main="Proportion of Variation")
+    if(pcplot) plot(object@variation, xlab="PC", ylab="Proportion", main="Proportion of Variation")
     return(object)
 })
 

--- a/R/CIDR.R
+++ b/R/CIDR.R
@@ -339,7 +339,7 @@ setGeneric("scPCA", function(object, plotPC=TRUE) {
 #'
 #' @examples
 #' example(cidr)
-setMethod("scPCA", "scData", function(object,pcplot){
+setMethod("scPCA", "scData", function(object,plotPC){
     y <- cidrPcoa(object@dissim)
     variation <- y$values
     ## store all eigenvalues - neg, 0, & pos
@@ -350,7 +350,7 @@ setMethod("scPCA", "scData", function(object,pcplot){
     variation <- variation/sum(variation)
     object@variation <- variation
 
-    if(pcplot) plot(object@variation, xlab="PC", ylab="Proportion", main="Proportion of Variation")
+    if(plotPC) plot(object@variation, xlab="PC", ylab="Proportion", main="Proportion of Variation")
     return(object)
 })
 

--- a/R/CIDR.R
+++ b/R/CIDR.R
@@ -314,7 +314,7 @@ setMethod("scDissim", "scData", function(object, correction, threads, useStepFun
       return(object)
 })
 
-setGeneric("scPCA", function(object) {
+setGeneric("scPCA", function(object, plotPC=TRUE) {
     standardGeneric("scPCA")
 })
 
@@ -327,7 +327,7 @@ setGeneric("scPCA", function(object) {
 #' @name scPCA
 #'
 #' @param object an scData class object.
-#' @param pcplot if TRUE, a plot of the PC variance explained is shown
+#' @param plotPC Boolean; if \code{TRUE}, a plot of PC variance explained is produced.
 #'
 #' @export
 #'
@@ -339,7 +339,7 @@ setGeneric("scPCA", function(object) {
 #'
 #' @examples
 #' example(cidr)
-setMethod("scPCA", "scData", function(object,pcplot=TRUE){
+setMethod("scPCA", "scData", function(object,pcplot){
     y <- cidrPcoa(object@dissim)
     variation <- y$values
     ## store all eigenvalues - neg, 0, & pos


### PR DESCRIPTION
If running CIDR many times, it produces a bunch of plots which can clog up the graphics display. This gives the user the option to not show the PC plot to speed things up and reduce side effects.